### PR TITLE
add index to inserted_at on events to speed things up

### DIFF
--- a/priv/repo/migrations/20231206154114_inserted_at_index.exs
+++ b/priv/repo/migrations/20231206154114_inserted_at_index.exs
@@ -1,0 +1,6 @@
+defmodule MailgunLogger.Repo.Migrations.InsertedAtIndex do
+  use Ecto.Migration
+  def change do
+    create(index(:events, [:inserted_at]))
+  end
+end


### PR DESCRIPTION
An index on the events table and inserted_at speeds up the page loads by an order of magnitude (on my machine).