### PR TITLE
Make trigger button a form again to fix Flop pagination

### DIFF
--- a/lib/mailgun_logger.ex
+++ b/lib/mailgun_logger.ex
@@ -20,7 +20,7 @@ defmodule MailgunLogger do
 
   ## Config
 
-  There is an option to store the raw messages received from the api. In the first version of the app everything was stored in the database but the seize of the table became huge in a very short time and the raw event data did not really offer added value. 
+  There is an option to store the raw messages received from the api. In the first version of the app everything was stored in the database but the seize of the table became huge in a very short time and the raw event data did not really offer added value.
   So we opted to store that data on S3 instead of in the database.
 
   ```
@@ -64,6 +64,16 @@ defmodule MailgunLogger do
     |> Enum.map(&Task.async(fn -> process_account(&1) end))
     |> Enum.map(&Task.await(&1, @ttl))
     |> List.flatten()
+  end
+
+  @doc """
+  Spawns a task to fetch new e-mails. If the task is already running, it will not be started again.
+  """
+  def run_async_if_not_running() do
+    if Process.whereis(:run_task) == nil do
+      {:ok, pid} = Task.start(&run/0)
+      Process.register(pid, :run_task)
+    end
   end
 
   @doc """

--- a/lib/mailgun_logger_web/controllers/page_controller.ex
+++ b/lib/mailgun_logger_web/controllers/page_controller.ex
@@ -8,6 +8,20 @@ defmodule MailgunLoggerWeb.PageController do
     redirect(conn, to: Routes.event_path(conn, :index))
   end
 
+  def trigger_run(conn, _) do
+    # run the task to fetch new emails
+    MailgunLogger.run_async_if_not_running()
+
+    # redirect to the current page to preserve the search query parameters
+    case List.keyfind(conn.req_headers, "referer", 0) do
+      {"referer", path} ->
+        redirect(conn, external: path)
+
+      _ ->
+        redirect(conn, to: Routes.event_path(conn, :index))
+    end
+  end
+
   def stats(conn, _) do
     total_accounts = Accounts.list_accounts() |> length()
 

--- a/lib/mailgun_logger_web/lives/run_triggerer.ex
+++ b/lib/mailgun_logger_web/lives/run_triggerer.ex
@@ -17,11 +17,11 @@ defmodule MailgunLogger.RunTriggererLive do
     """
   end
 
-  def handle_event("trigger_run", _, socket) do
-    Task.start(&MailgunLogger.run/0)
-    Process.send_after(self(), :reset, 3000)
-    {:noreply, assign(socket, :triggered?, true)}
-  end
+  # def handle_event("trigger_run", _, socket) do
+  #   Task.start(&MailgunLogger.run/0)
+  #   Process.send_after(self(), :reset, 3000)
+  #   {:noreply, assign(socket, :triggered?, true)}
+  # end
 
   def handle_info(:reset, socket) do
     {:noreply, assign(socket, :triggered?, false)}

--- a/lib/mailgun_logger_web/router.ex
+++ b/lib/mailgun_logger_web/router.ex
@@ -79,6 +79,7 @@ defmodule MailgunLoggerWeb.Router do
     resources("/users", UserController, except: [:show])
 
     get("/", PageController, :index)
+    post("/trigger-run", PageController, :trigger_run)
     get("/stats", PageController, :stats)
     get("/graphs", PageController, :graphs)
     get("/non-affiliation", PageController, :non_affiliation)

--- a/lib/mailgun_logger_web/templates/event/index.html.heex
+++ b/lib/mailgun_logger_web/templates/event/index.html.heex
@@ -1,6 +1,9 @@
 <div style="display: flex; align-items: center; justify-content: space-between">
   <h1>Events</h1>
-  <%= live_render(@conn, MailgunLogger.RunTriggererLive) %>
+  <%= # live_render(@conn, MailgunLogger.RunTriggererLive) %>
+  <%= form_for @conn, ~p"/trigger-run", fn f -> %>
+    <%= submit "Trigger Run" %>
+  <% end %>
 </div>
 
   <.flash_group flash={@flash} />

--- a/priv/repo/migrations/20231206154114_inserted_at_index.exs
+++ b/priv/repo/migrations/20231206154114_inserted_at_index.exs
@@ -1,0 +1,6 @@
+defmodule MailgunLogger.Repo.Migrations.InsertedAtIndex do
+  use Ecto.Migration
+  def change do
+    create(index(:events, [:inserted_at]))
+  end
+end


### PR DESCRIPTION
The trigger button is now a regular form with a POST request. 

LiveView on a page makes Flop use LV pagination, which only works if the entire page is a live page, and not just a live component.

See: https://github.com/woylie/flop_phoenix/discussions/243#discussioncomment-7778544