### PR TITLE
TobiasHungwe - Mailgun_logger Assignment 

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -8,7 +8,6 @@ config :mailgun_logger, MailgunLoggerWeb.Endpoint,
   code_reloader: false,
   version: Application.spec(:mailgun_logger, :vsn)
 
-
 config :logger,
   level: String.to_existing_atom(System.get_env("ML_LOG_LEVEL", "info")) || :info,
   compile_time_purge_matching: [[application: :remote_ip]]

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,8 +7,7 @@ config :mailgun_logger, MailgunLoggerWeb.Endpoint,
   server: false
 
 # Quantum cron schedule
-config :mailgun_logger, MailgunLogger.Scheduler,
-  jobs: []
+config :mailgun_logger, MailgunLogger.Scheduler, jobs: []
 
 config :logger, level: :warning
 config :mailgun_logger, MailgunLogger.Repo, pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/mailgun_logger/roles/roles.ex
+++ b/lib/mailgun_logger/roles/roles.ex
@@ -7,14 +7,17 @@ defmodule MailgunLogger.Roles do
 
   @superuser_role "superuser"
   @admin_role "admin"
+  @member_role "member"
 
   #########################################################
 
   @default_actions ~w()
 
-  @admin_actions ~w(do_stuff) ++ @default_actions
+  @admin_actions ~w(do_stuff) ++ @default_actions ++ @member_actions
 
   @superuser_actions ~w() ++ @admin_actions
+
+  @member_actions ~w() ++ @default_actions
 
   #########################################################
 
@@ -55,6 +58,12 @@ defmodule MailgunLogger.Roles do
     Enum.any?(roles, &can?(&1.name, action))
   end
 
+
+  for action <- @member_actions do
+    action = String.to_atom(action)
+    def can?(@member_role, unquote(action)), do: true
+  end
+
   for action <- @admin_actions do
     action = String.to_atom(action)
     def can?(@admin_role, unquote(action)), do: true
@@ -69,12 +78,14 @@ defmodule MailgunLogger.Roles do
 
   def is?(%User{roles: roles}, :superuser), do: is(roles, "superuser")
   def is?(%User{roles: roles}, :admin), do: is(roles, "admin")
+  def is?(%User{roles: roles}, :member), do: is(roles, "member")
   def is?(_, _), do: raise("Roles.is/2 requires roles to be preloaded")
 
   defp is(roles, role) when is_binary(role), do: Enum.map(roles, & &1.name) |> Enum.member?(role)
 
   def abilities(%User{roles: []}), do: []
   def abilities(%User{roles: roles}), do: hd(roles) |> abilities()
+  def abilities(%Role{name: "member"}), do: @member_actions
   def abilities(%Role{name: "admin"}), do: @admin_actions
   def abilities(%Role{name: "superuser"}), do: @superuser_actions
 

--- a/lib/mailgun_logger/roles/roles.ex
+++ b/lib/mailgun_logger/roles/roles.ex
@@ -12,12 +12,9 @@ defmodule MailgunLogger.Roles do
   #########################################################
 
   @default_actions ~w()
-
-  @admin_actions ~w(do_stuff) ++ @default_actions ++ @member_actions
-
+  @member_actions ~w(view_events) ++ @default_actions
+  @admin_actions ~w(do_stuff) ++ @member_actions
   @superuser_actions ~w() ++ @admin_actions
-
-  @member_actions ~w() ++ @default_actions
 
   #########################################################
 
@@ -57,7 +54,6 @@ defmodule MailgunLogger.Roles do
   def can?(roles, action) when is_list(roles) do
     Enum.any?(roles, &can?(&1.name, action))
   end
-
 
   for action <- @member_actions do
     action = String.to_atom(action)

--- a/lib/mailgun_logger/roles/roles.ex
+++ b/lib/mailgun_logger/roles/roles.ex
@@ -13,7 +13,7 @@ defmodule MailgunLogger.Roles do
 
   @default_actions ~w()
   @member_actions ~w(view_events) ++ @default_actions
-  @admin_actions ~w(do_stuff) ++ @member_actions
+  @admin_actions ~w(do_stuff manage_roles) ++ @member_actions
   @superuser_actions ~w() ++ @admin_actions
 
   #########################################################

--- a/lib/mailgun_logger/seeder.ex
+++ b/lib/mailgun_logger/seeder.ex
@@ -6,7 +6,7 @@ defmodule MailgunLogger.Seeder do
 
   # alias MailgunLogger.UserRole
 
-  @roles [%Role{name: "superuser"}, %Role{name: "admin"}]
+  @roles [%Role{name: "superuser"}, %Role{name: "admin"}, %Role{name: "member"}]
 
   def run do
     Enum.each(@roles, &insert_if_new(&1))

--- a/lib/mailgun_logger/users/users.ex
+++ b/lib/mailgun_logger/users/users.ex
@@ -4,7 +4,6 @@ defmodule MailgunLogger.Users do
   alias MailgunLogger.Repo
   alias MailgunLogger.User
 
-
   @type ecto_user() :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   @type maybe_user() :: User.t() | nil
 

--- a/lib/mailgun_logger/users/users.ex
+++ b/lib/mailgun_logger/users/users.ex
@@ -150,10 +150,26 @@ defmodule MailgunLogger.Users do
     |> Repo.insert()
   end
 
+  @spec create_user_with_roles(map, [MailgunLogger.Role.t()]) :: ecto_user()
+  def create_user_with_roles(params, roles) do
+    %User{}
+    |> User.changeset(params)
+    |> Ecto.Changeset.put_assoc(:roles, roles)
+    |> Repo.insert()
+  end
+
   @spec update_user(User.t(), map) :: ecto_user()
   def update_user(user, params) do
     user
     |> User.update_changeset(params)
+    |> Repo.update()
+  end
+
+  @spec update_user_with_roles(User.t(), map, [MailgunLogger.Role.t()]) :: ecto_user()
+  def update_user_with_roles(user, params, roles) do
+    user
+    |> User.update_changeset(params)
+    |> Ecto.Changeset.put_assoc(:roles, roles)
     |> Repo.update()
   end
 

--- a/lib/mailgun_logger_web/components/core_components.ex
+++ b/lib/mailgun_logger_web/components/core_components.ex
@@ -79,7 +79,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
                 </button>
               </div>
               <div id={"#{@id}-content"}>
-                <%= render_slot(@inner_block) %>
+                {render_slot(@inner_block)}
               </div>
             </.focus_wrap>
           </div>
@@ -122,9 +122,9 @@ defmodule MailgunLoggerWeb.CoreComponents do
       <p :if={@title} class="flex items-center gap-1.5 text-sm font-semibold leading-6">
         <.icon :if={@kind == :info} name="hero-information-circle-mini" class="h-4 w-4" />
         <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="h-4 w-4" />
-        <%= @title %>
+        {@title}
       </p>
-      <p class="mt-2 text-sm leading-5"><%= msg %></p>
+      <p class="mt-2 text-sm leading-5">{msg}</p>
       <button type="button" class="group absolute top-1 right-1 p-2" aria-label={gettext("close")}>
         <.icon name="hero-x-mark-solid" class="h-5 w-5 opacity-40 group-hover:opacity-70" />
       </button>
@@ -186,9 +186,9 @@ defmodule MailgunLoggerWeb.CoreComponents do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
       <div class="mt-10 space-y-8 bg-white">
-        <%= render_slot(@inner_block, f) %>
+        {render_slot(@inner_block, f)}
         <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
-          <%= render_slot(action, f) %>
+          {render_slot(action, f)}
         </div>
       </div>
     </.form>
@@ -220,7 +220,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
       ]}
       {@rest}
     >
-      <%= render_slot(@inner_block) %>
+      {render_slot(@inner_block)}
     </button>
     """
   end
@@ -291,9 +291,9 @@ defmodule MailgunLoggerWeb.CoreComponents do
           checked={@checked}
           {@rest}
         />
-        <%= @label %>
+        {@label}
       </label>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """
   end
@@ -301,7 +301,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div class="form-group">
-      <.label for={@id}><%= @label %></.label>
+      <.label for={@id}>{@label}</.label>
       <select
         id={@id}
         name={@name}
@@ -309,10 +309,10 @@ defmodule MailgunLoggerWeb.CoreComponents do
         multiple={@multiple}
         {@rest}
       >
-        <option :if={@prompt} value=""><%= @prompt %></option>
-        <%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
+        <option :if={@prompt} value="">{@prompt}</option>
+        {Phoenix.HTML.Form.options_for_select(@options, @value)}
       </select>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """
   end
@@ -320,14 +320,14 @@ defmodule MailgunLoggerWeb.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div class="form-group">
-      <.label for={@id}><%= @label %></.label>
+      <.label for={@id}>{@label}</.label>
       <textarea
         id={@id}
         name={@name}
         class="form-control"
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """
   end
@@ -336,7 +336,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
   def input(assigns) do
     ~H"""
     <div class="form-group">
-      <.label for={@id}><%= @label %></.label>
+      <.label for={@id}>{@label}</.label>
       <input
         type={@type}
         name={@name}
@@ -346,7 +346,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
         class="form-control"
         {@rest}
       />
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <.error :for={msg <- @errors}>{msg}</.error>
     </div>
     """
   end
@@ -360,7 +360,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
   def label(assigns) do
     ~H"""
     <label for={@for} class="control-label">
-      <%= render_slot(@inner_block) %>
+      {render_slot(@inner_block)}
     </label>
     """
   end
@@ -373,7 +373,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
   def error(assigns) do
     ~H"""
     <p class="validation-error">
-      <%= render_slot(@inner_block) %>
+      {render_slot(@inner_block)}
     </p>
     """
   end
@@ -392,13 +392,13 @@ defmodule MailgunLoggerWeb.CoreComponents do
     <header class={[@actions != [] && "flex items-center justify-between gap-6", @class]}>
       <div>
         <h1 class="text-lg font-semibold leading-8 text-zinc-800">
-          <%= render_slot(@inner_block) %>
+          {render_slot(@inner_block)}
         </h1>
         <p :if={@subtitle != []} class="mt-2 text-sm leading-6 text-zinc-600">
-          <%= render_slot(@subtitle) %>
+          {render_slot(@subtitle)}
         </p>
       </div>
-      <div class="flex-none"><%= render_slot(@actions) %></div>
+      <div class="flex-none">{render_slot(@actions)}</div>
     </header>
     """
   end
@@ -440,8 +440,8 @@ defmodule MailgunLoggerWeb.CoreComponents do
       <table class="w-[40rem] mt-11 sm:w-full">
         <thead class="text-sm text-left leading-6 text-zinc-500">
           <tr>
-            <th :for={col <- @col} class="p-0 pr-6 pb-4 font-normal"><%= col[:label] %></th>
-            <th class="relative p-0 pb-4"><span class="sr-only"><%= gettext("Actions") %></span></th>
+            <th :for={col <- @col} class="p-0 pr-6 pb-4 font-normal">{col[:label]}</th>
+            <th class="relative p-0 pb-4"><span class="sr-only">{gettext("Actions")}</span></th>
           </tr>
         </thead>
         <tbody
@@ -458,7 +458,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
               <div class="block py-4 pr-6">
                 <span class="absolute -inset-y-px right-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
                 <span class={["relative", i == 0 && "font-semibold text-zinc-900"]}>
-                  <%= render_slot(col, @row_item.(row)) %>
+                  {render_slot(col, @row_item.(row))}
                 </span>
               </div>
             </td>
@@ -469,7 +469,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
                   :for={action <- @action}
                   class="relative ml-4 font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
                 >
-                  <%= render_slot(action, @row_item.(row)) %>
+                  {render_slot(action, @row_item.(row))}
                 </span>
               </div>
             </td>
@@ -499,8 +499,8 @@ defmodule MailgunLoggerWeb.CoreComponents do
     <div class="mt-14">
       <dl class="-my-4 divide-y divide-zinc-100">
         <div :for={item <- @item} class="flex gap-4 py-4 text-sm leading-6 sm:gap-8">
-          <dt class="w-1/4 flex-none text-zinc-500"><%= item.title %></dt>
-          <dd class="text-zinc-700"><%= render_slot(item) %></dd>
+          <dt class="w-1/4 flex-none text-zinc-500">{item.title}</dt>
+          <dd class="text-zinc-700">{render_slot(item)}</dd>
         </div>
       </dl>
     </div>
@@ -525,7 +525,7 @@ defmodule MailgunLoggerWeb.CoreComponents do
         class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
       >
         <.icon name="hero-arrow-left-solid" class="h-3 w-3" />
-        <%= render_slot(@inner_block) %>
+        {render_slot(@inner_block)}
       </.link>
     </div>
     """

--- a/lib/mailgun_logger_web/controllers/setup_controller.ex
+++ b/lib/mailgun_logger_web/controllers/setup_controller.ex
@@ -15,7 +15,7 @@ defmodule MailgunLoggerWeb.SetupController do
     end
   end
 
- def create_root(conn, %{"user" => params}) do
+  def create_root(conn, %{"user" => params}) do
     # Only allow create_root if there are no users in the database yet,
     # otherwise it's possible for any unauthenticated request to this
     # endpoint to make an admin user.

--- a/lib/mailgun_logger_web/controllers/user_controller.ex
+++ b/lib/mailgun_logger_web/controllers/user_controller.ex
@@ -1,6 +1,7 @@
 defmodule MailgunLoggerWeb.UserController do
   use MailgunLoggerWeb, :controller
 
+  alias MailgunLogger.Roles
   alias MailgunLogger.Users
   alias MailgunLogger.User
 
@@ -10,43 +11,105 @@ defmodule MailgunLoggerWeb.UserController do
   end
 
   def new(conn, _) do
+    current_user = conn.assigns[:current_user]
     changeset = User.changeset(%User{})
-    render(conn, :new, changeset: changeset)
+
+    render(conn, :new,
+      changeset: changeset,
+      all_roles: Roles.list_roles(),
+      selected_role_ids: [],
+      show_roles?: Roles.can?(current_user, :manage_roles)
+    )
   end
 
   def create(conn, %{"user" => params}) do
-    case Users.create_user(params) do
-      {:ok, _} -> redirect(conn, to: Routes.user_path(conn, :index))
-      {:error, changeset} -> render(conn, :new, changeset: changeset)
+    current_user = conn.assigns[:current_user]
+    roles = resolve_roles(current_user, params, [])
+
+    case Users.create_user_with_roles(params, roles) do
+      {:ok, _user} ->
+        conn
+        |> put_flash(:info, "User created successfully.")
+        |> redirect(to: Routes.user_path(conn, :index))
+
+      {:error, changeset} ->
+        render(conn, :new,
+          changeset: changeset,
+          all_roles: Roles.list_roles(),
+          selected_role_ids: Enum.map(roles, & &1.id),
+          show_roles?: Roles.can?(current_user, :manage_roles)
+        )
     end
   end
 
   def edit(conn, %{"id" => id}) do
+    current_user = conn.assigns[:current_user]
     user = Users.get_user!(id)
-    changeset = User.changeset(user)
-    render(conn, :edit, changeset: changeset, user: user)
+    changeset = User.update_changeset(user)
+
+    render(conn, :edit,
+      changeset: changeset,
+      user: user,
+      all_roles: Roles.list_roles(),
+      selected_role_ids: Enum.map(user.roles, & &1.id),
+      show_roles?: Roles.can?(current_user, :manage_roles)
+    )
   end
 
   def update(conn, %{"id" => id, "user" => params}) do
+    current_user = conn.assigns[:current_user]
     user = Users.get_user!(id)
+    roles = resolve_roles(current_user, params, user.roles)
 
-    case Users.update_user(user, params) do
-      {:ok, _} ->
-        redirect(conn, to: Routes.user_path(conn, :index))
+    if Roles.can?(current_user, :manage_roles) && current_user.id == user.id &&
+         self_downgrade?(current_user, roles) do
+      conn
+      |> put_flash(:error, "You cannot remove your own role.")
+      |> render(:edit,
+        changeset: User.update_changeset(user, params),
+        user: user,
+        all_roles: Roles.list_roles(),
+        selected_role_ids: Enum.map(roles, & &1.id),
+        show_roles?: true
+      )
+    else
+      case Users.update_user_with_roles(user, params, roles) do
+        {:ok, _updated} ->
+          conn
+          |> put_flash(:info, "User updated successfully.")
+          |> redirect(to: Routes.user_path(conn, :index))
 
-      {:error, changeset} ->
-        render(conn, :edit, changeset: changeset, user: user)
+        {:error, changeset} ->
+          render(conn, :edit,
+            changeset: changeset,
+            user: user,
+            all_roles: Roles.list_roles(),
+            selected_role_ids: Enum.map(roles, & &1.id),
+            show_roles?: Roles.can?(current_user, :manage_roles)
+          )
+      end
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    {:ok, _} =
-      id
-      |> Users.get_user!()
-      |> Users.delete_user()
+    {:ok, _} = id |> Users.get_user!() |> Users.delete_user()
 
     conn
     |> put_flash(:info, "user deleted successfully.")
     |> redirect(to: Routes.user_path(conn, :index))
+  end
+
+  defp resolve_roles(current_user, params, existing_roles) do
+    if Roles.can?(current_user, :manage_roles) do
+      params |> Map.get("role_ids", []) |> Enum.map(&String.to_integer/1) |> Roles.get_roles_by_id()
+    else
+      existing_roles
+    end
+  end
+
+  defp self_downgrade?(%User{roles: current_roles}, new_roles) do
+    current_ids = MapSet.new(current_roles, & &1.id)
+    new_ids = MapSet.new(new_roles, & &1.id)
+    not MapSet.subset?(current_ids, new_ids)
   end
 end

--- a/lib/mailgun_logger_web/plugs/require_permission.ex
+++ b/lib/mailgun_logger_web/plugs/require_permission.ex
@@ -9,11 +9,8 @@ defmodule MailgunLoggerWeb.Plugs.RequirePermission do
   Enforces that the authenticated user has the required permission.
   This plug expects MailgunLoggerWeb.Plugs.Auth to have assigned :current_user.
   """
-
-  @spec init(atom()) :: atom()
   def init(permission), do: permission
 
-  @spec call(Plug.Conn.t(), atom()) :: Plug.Conn.t()
   def call(conn, permission) do
     user = conn.assigns[:current_user]
 

--- a/lib/mailgun_logger_web/plugs/require_permission.ex 
+++ b/lib/mailgun_logger_web/plugs/require_permission.ex 
@@ -1,0 +1,29 @@
+defmodule MailgunLoggerWeb.Plugs.RequirePermission do
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias MailgunLogger.Roles
+  alias MailgunLoggerWeb.Router.Helpers, as: Routes
+
+  @moduledoc """
+  Enforces that the authenticated user has the required permission.
+  This plug expects MailgunLoggerWeb.Plugs.Auth to have assigned :current_user.
+  """
+
+  @spec init(atom()) :: atom()
+  def init(permission), do: permission
+
+  @spec call(Plug.Conn.t(), atom()) :: Plug.Conn.t()
+  def call(conn, permission) do
+    user = conn.assigns[:current_user]
+
+    if user && Roles.can?(user, permission) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You do not have permission to access this page.")
+      |> redirect(to: Routes.event_path(conn, :index))
+      |> halt()
+    end
+  end
+end

--- a/lib/mailgun_logger_web/router.ex
+++ b/lib/mailgun_logger_web/router.ex
@@ -31,8 +31,6 @@ defmodule MailgunLoggerWeb.Router do
     plug(MailgunLoggerWeb.Plugs.RequirePermission, :do_stuff)
   end
 
-
-
   # Always except in prod
   if Application.compile_env(:mailgun_logger, :env) == :dev do
     forward("/sent_emails", Bamboo.SentEmailViewerPlug)

--- a/lib/mailgun_logger_web/router.ex
+++ b/lib/mailgun_logger_web/router.ex
@@ -23,6 +23,16 @@ defmodule MailgunLoggerWeb.Router do
     plug(MailgunLoggerWeb.Plugs.Auth)
   end
 
+  pipeline :require_events_access do
+    plug(MailgunLoggerWeb.Plugs.RequirePermission, :view_events)
+  end
+
+  pipeline :require_admin_access do
+    plug(MailgunLoggerWeb.Plugs.RequirePermission, :do_stuff)
+  end
+
+
+
   # Always except in prod
   if Application.compile_env(:mailgun_logger, :env) == :dev do
     forward("/sent_emails", Bamboo.SentEmailViewerPlug)
@@ -73,18 +83,28 @@ defmodule MailgunLoggerWeb.Router do
     pipe_through([:browser, :auth])
 
     get("/logout", AuthController, :logout)
+    get("/profile", ProfileController, :edit)
+    put("/profile", ProfileController, :update)
+  end
+
+  scope "/", MailgunLoggerWeb do
+    pipe_through([:browser, :auth, :require_events_access])
+
+    get("/", PageController, :index)
+    get("/non-affiliation", PageController, :non_affiliation)
 
     resources("/events", EventController, only: [:index, :show])
     get("/events/:id/stored_message", EventController, :stored_message)
+  end
+
+  scope "/", MailgunLoggerWeb do
+    pipe_through([:browser, :auth, :require_admin_access])
+
     resources("/accounts", AccountController, except: [:show])
-    get("/profile", ProfileController, :edit)
-    put("/profile", ProfileController, :update)
     resources("/users", UserController, except: [:show])
 
-    get("/", PageController, :index)
     post("/trigger-run", PageController, :trigger_run)
     get("/stats", PageController, :stats)
     get("/graphs", PageController, :graphs)
-    get("/non-affiliation", PageController, :non_affiliation)
   end
 end

--- a/lib/mailgun_logger_web/templates/account/edit.html.heex
+++ b/lib/mailgun_logger_web/templates/account/edit.html.heex
@@ -1,4 +1,15 @@
 <h1>Edit account</h1>
-<%= render "form.html", action: Routes.account_path(@conn, :update, @account), changeset: @changeset, flash: @flash %>
+{render("form.html",
+  action: Routes.account_path(@conn, :update, @account),
+  changeset: @changeset,
+  flash: @flash
+)}
 <br />
-<.link href={Routes.account_path(@conn, :delete, @account)} method="delete" data-confirm="Are you sure?" class="btn btn-danger btn-sm">delete</.link>
+<.link
+  href={Routes.account_path(@conn, :delete, @account)}
+  method="delete"
+  data-confirm="Are you sure?"
+  class="btn btn-danger btn-sm"
+>
+  delete
+</.link>

--- a/lib/mailgun_logger_web/templates/account/form.html.heex
+++ b/lib/mailgun_logger_web/templates/account/form.html.heex
@@ -3,22 +3,32 @@
     <p>Oops, something went wrong! Please check the errors below.</p>
   </div>
 
-  <p>These settings can be found on your Mailgun dashboard. An account covers a sending domain / API key combo. If you have multiple domains, add them on seperate accounts.</p>
+  <p>
+    These settings can be found on your Mailgun dashboard. An account covers a sending domain / API key combo. If you have multiple domains, add them on seperate accounts.
+  </p>
 
   <div :if={Phoenix.Flash.get(@flash, :info)} class="alert alert-info" role="info">
-    <%= Phoenix.Flash.get(@flash, :info) %>
+    {Phoenix.Flash.get(@flash, :info)}
   </div>
 
   <.input field={f[:domain]} label="Sending domain" />
-  <div class="form-hint"><a href="https://app.mailgun.com/app/sending/domains" target="_blank">Find on Mailgun dashboard</a></div>
+  <div class="form-hint">
+    <a href="https://app.mailgun.com/app/sending/domains" target="_blank">
+      Find on Mailgun dashboard
+    </a>
+  </div>
 
   <.input field={f[:api_key]} label="API key" />
-  <div class="form-hint"><a href="https://app.mailgun.com/app/account/security/api_keys" target="_blank">Find on Mailgun dashboard</a></div>
+  <div class="form-hint">
+    <a href="https://app.mailgun.com/app/account/security/api_keys" target="_blank">
+      Find on Mailgun dashboard
+    </a>
+  </div>
 
   <.input field={f[:is_active]} type="checkbox" label="Is active" />
   <.input field={f[:is_eu]} type="checkbox" label="Is EU" />
 
   <div class="form-group mt-5">
-    <%= submit "submit", class: "btn btn-primary"%>
+    {submit("submit", class: "btn btn-primary")}
   </div>
 </.form>

--- a/lib/mailgun_logger_web/templates/account/index.html.heex
+++ b/lib/mailgun_logger_web/templates/account/index.html.heex
@@ -12,16 +12,16 @@
   </thead>
   <tbody>
     <%= for account <- @accounts do %>
-    <tr>
-      <td><%= account.domain %></td>
-      <td><%= account.api_key %></td>
-      <td><span :if={account.is_eu}>EU</span></td>
-      <td>
-        <pre :if={account.is_active} class="dot active">active</pre>
-        <pre :if={!account.is_active} class="dot inactive">inactive</pre>
-      </td>
-      <td><.link href={Routes.account_path(@conn, :edit, account)}>edit</.link></td>
-    </tr>
+      <tr>
+        <td>{account.domain}</td>
+        <td>{account.api_key}</td>
+        <td><span :if={account.is_eu}>EU</span></td>
+        <td>
+          <pre :if={account.is_active} class="dot active">active</pre>
+          <pre :if={!account.is_active} class="dot inactive">inactive</pre>
+        </td>
+        <td><.link href={Routes.account_path(@conn, :edit, account)}>edit</.link></td>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/lib/mailgun_logger_web/templates/account/new.html.heex
+++ b/lib/mailgun_logger_web/templates/account/new.html.heex
@@ -1,2 +1,2 @@
 <h1>New account</h1>
-<%= render "form.html", action: ~p"/accounts", changeset: @changeset, flash: @flash %>
+{render("form.html", action: ~p"/accounts", changeset: @changeset, flash: @flash)}

--- a/lib/mailgun_logger_web/templates/auth/new.html.heex
+++ b/lib/mailgun_logger_web/templates/auth/new.html.heex
@@ -1,24 +1,26 @@
 <div class="login-wrapper">
   <div class="login-panel">
-    <h2><%= gettext("Inloggen") %></h2>
+    <h2>{gettext("Inloggen")}</h2>
 
     <div :if={Phoenix.Flash.get(@flash, :info)} class="alert alert-info" role="alert">
-      <%= Phoenix.Flash.get(@flash, :info) %>
+      {Phoenix.Flash.get(@flash, :info)}
     </div>
 
     <div :if={Phoenix.Flash.get(@flash, :error)} class="validation-error" role="alert">
-      <%= Phoenix.Flash.get(@flash, :error) %>
+      {Phoenix.Flash.get(@flash, :error)}
     </div>
 
     <.form :let={f} for={@conn} action={Routes.auth_path(@conn, :create)} as={:user} novalidate>
       <.input field={f[:email]} type="email" label={gettext("Email")} required autofocus />
       <.input field={f[:password]} type="password" label={gettext("Password")} required />
 
-      <%= submit gettext("Inloggen"), class: "btn btn-primary" %>
+      {submit(gettext("Inloggen"), class: "btn btn-primary")}
     </.form>
 
-    <hr>
+    <hr />
 
-    <.link href={Routes.password_reset_path(@conn, :request_new)}><%= gettext("Forgot password?") %></.link>
+    <.link href={Routes.password_reset_path(@conn, :request_new)}>
+      {gettext("Forgot password?")}
+    </.link>
   </div>
 </div>

--- a/lib/mailgun_logger_web/templates/event/index.html.heex
+++ b/lib/mailgun_logger_web/templates/event/index.html.heex
@@ -1,7 +1,7 @@
 <div class="page-header">
   <h1>Events</h1>
   <.form for={@conn} action={~p"/trigger-run"}>
-    <%= submit("Trigger Run") %>
+    {submit("Trigger Run")}
   </.form>
 </div>
 
@@ -26,15 +26,21 @@
   </div>
   <%= for event <- @events do %>
     <div class="log-row">
-      <span class="log-col-event"><%= event_name(event.event) %></span>
-      <span class="log-col-level"><%= event_type(event.log_level) %></span>
-      <span class="log-col-dir"><%= send_recv(event.method) %></span>
-      <span class="log-col-ts"><%= event.timestamp %></span>
-      <span class="log-col-from" title={event.message_from}><%= event.message_from %></span>
-      <span class="log-col-to" title={event.recipient}><%= event.recipient %></span>
-      <span class="log-col-subject" title={event.message_subject}><%= event.message_subject %></span>
+      <span class="log-col-event">{event_name(event.event)}</span>
+      <span class="log-col-level">{event_type(event.log_level)}</span>
+      <span class="log-col-dir">{send_recv(event.method)}</span>
+      <span class="log-col-ts">{event.timestamp}</span>
+      <span class="log-col-from" title={event.message_from}>{event.message_from}</span>
+      <span class="log-col-to" title={event.recipient}>{event.recipient}</span>
+      <span class="log-col-subject" title={event.message_subject}>{event.message_subject}</span>
       <span class="log-col-actions">
-        <a :if={event.event in ~w(delivered accepted failed)} href={Routes.event_path(@conn, :stored_message, event.id)} target="_blank">msg</a>
+        <a
+          :if={event.event in ~w(delivered accepted failed)}
+          href={Routes.event_path(@conn, :stored_message, event.id)}
+          target="_blank"
+        >
+          msg
+        </a>
         <.link href={Routes.event_path(@conn, :show, event.id)}>detail</.link>
       </span>
     </div>
@@ -42,7 +48,12 @@
 </div>
 
 <div class="pagination-wrapper">
-  <Flop.Phoenix.pagination meta={@meta} path={~p"/events"} class="pagination-nav" disabled_link_attrs={[class: "pagination-btn pagination-btn--disabled"]}>
+  <Flop.Phoenix.pagination
+    meta={@meta}
+    path={~p"/events"}
+    class="pagination-nav"
+    disabled_link_attrs={[class: "pagination-btn pagination-btn--disabled"]}
+  >
     <:previous attrs={[class: "pagination-btn"]}>
       ← Previous
     </:previous>

--- a/lib/mailgun_logger_web/templates/event/show.html.heex
+++ b/lib/mailgun_logger_web/templates/event/show.html.heex
@@ -1,38 +1,42 @@
 <dl :if={@event.event == "failed"} class="dl-error">
   <dt>Error detail</dt>
-  <dd><%= error_msg(@event) %></dd>
+  <dd>{error_msg(@event)}</dd>
 </dl>
 <dl>
   <dt>Recipient</dt>
-  <dd><%= @event.recipient %></dd>
+  <dd>{@event.recipient}</dd>
   <dt>Message subject</dt>
-  <dd><%= @event.message_subject %></dd>
+  <dd>{@event.message_subject}</dd>
   <dt>Account</dt>
-  <dd><%= @event.account.domain %></dd>
+  <dd>{@event.account.domain}</dd>
   <dt>Event</dt>
-  <dd><%= event_name(@event.event) %></dd>
+  <dd>{event_name(@event.event)}</dd>
   <dt>Method</dt>
-  <dd><%= @event.method %></dd>
+  <dd>{@event.method}</dd>
   <dt>Attachments</dt>
-  <dd><%= list_attachments(@event.raw) %></dd>
+  <dd>{list_attachments(@event.raw)}</dd>
   <dt>Timestamp</dt>
-  <dd><%= @event.timestamp %></dd>
+  <dd>{@event.timestamp}</dd>
   <dt>From</dt>
-  <dd><%= @event.message_from %></dd>
+  <dd>{@event.message_from}</dd>
   <dt>Linked events</dt>
   <dd>
     <ul class="linked-events">
       <%= for linked <- @event.linked_events do %>
-        <li><a href={Routes.event_path(@conn, :show, linked)}><%= linked.event %> (<%= linked.timestamp %>)</a></li>
+        <li>
+          <a href={Routes.event_path(@conn, :show, linked)}>
+            {linked.event} ({linked.timestamp})
+          </a>
+        </li>
       <% end %>
     </ul>
   </dd>
   <%= if Application.get_env(:mailgun_logger, :store_messages) and @event.has_stored_message do %>
-  <dt>Raw Stored Message data</dt>
-  <dd><a href={stored_message_url(@event.api_id)}>view json file on S3</a></dd>
-  <dt>Actual sent email</dt>
-  <dd><a href={Routes.event_path(@conn, :stored_message, @event)} target="_blank">view</a></dd>
+    <dt>Raw Stored Message data</dt>
+    <dd><a href={stored_message_url(@event.api_id)}>view json file on S3</a></dd>
+    <dt>Actual sent email</dt>
+    <dd><a href={Routes.event_path(@conn, :stored_message, @event)} target="_blank">view</a></dd>
   <% end %>
   <dt>Dev Stuff</dt>
-  <dd><%= pretty_raw(@event.raw) %></dd>
+  <dd>{pretty_raw(@event.raw)}</dd>
 </dl>

--- a/lib/mailgun_logger_web/templates/event/stored_message.html.heex
+++ b/lib/mailgun_logger_web/templates/event/stored_message.html.heex
@@ -1,1 +1,1 @@
-<%= raw(@html) %>
+{raw(@html)}

--- a/lib/mailgun_logger_web/templates/layout/app.html.heex
+++ b/lib/mailgun_logger_web/templates/layout/app.html.heex
@@ -38,10 +38,16 @@
           </div>
           <ul>
             <%= if assigns[:current_user] do %>
-              <li><.link href={Routes.event_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.EventController)}>Events</.link></li>
-              <li><.link href={Routes.page_path(@conn, :stats)} class={active_link_class(@conn, MailgunLoggerWeb.PageController, :index)}>Stats</.link></li>
-              <li><.link href={Routes.account_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}>Accounts</.link></li>
-              <li><.link href={Routes.user_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}>Users</.link></li>
+              <%= if MailgunLogger.Roles.can?(@current_user, :view_events) do %>
+                <li><.link href={Routes.event_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.EventController)}>Events</.link></li>
+              <% end %>
+
+              <%= if MailgunLogger.Roles.can?(@current_user, :do_stuff) do %>
+                <li><.link href={Routes.page_path(@conn, :stats)} class={active_link_class(@conn, MailgunLoggerWeb.PageController, :stats)}>Stats</.link></li>
+                <li><.link href={Routes.account_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}>Accounts</.link></li>
+                <li><.link href={Routes.user_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}>Users</.link></li>
+              <% end %>
+
               <li class="nav-right">
                 <details class="nav-dropdown">
                   <summary class="nav-dropdown-toggle">

--- a/lib/mailgun_logger_web/templates/layout/app.html.heex
+++ b/lib/mailgun_logger_web/templates/layout/app.html.heex
@@ -1,14 +1,18 @@
 <!DOCTYPE html>
 <html lang="en" data-theme={theme_preference(assigns)} data-user-theme={theme_preference(assigns)}>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="Jack + Joe">
-    <meta name="version" content={Application.spec(:mailgun_logger, :vsn)}>
-    <meta name="env" content={to_string(Application.get_env(:mailgun_logger, :env))}>
-    <title>Mailgun Logger v<%= Application.spec(:mailgun_logger, :vsn) %></title>
-    <link rel="icon" type="image/png" href={Routes.static_path(@conn, "/assets/images/favicon.png")} />
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/css/style.css")}>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="author" content="Jack + Joe" />
+    <meta name="version" content={Application.spec(:mailgun_logger, :vsn)} />
+    <meta name="env" content={to_string(Application.get_env(:mailgun_logger, :env))} />
+    <title>Mailgun Logger v{Application.spec(:mailgun_logger, :vsn)}</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href={Routes.static_path(@conn, "/assets/images/favicon.png")}
+    />
+    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/css/style.css")} />
     <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
     <script>
       (function() {
@@ -39,25 +43,62 @@
           <ul>
             <%= if assigns[:current_user] do %>
               <%= if MailgunLogger.Roles.can?(@current_user, :view_events) do %>
-                <li><.link href={Routes.event_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.EventController)}>Events</.link></li>
+                <li>
+                  <.link
+                    href={Routes.event_path(@conn, :index)}
+                    class={active_link_class(@conn, MailgunLoggerWeb.EventController)}
+                  >
+                    Events
+                  </.link>
+                </li>
               <% end %>
 
               <%= if MailgunLogger.Roles.can?(@current_user, :do_stuff) do %>
-                <li><.link href={Routes.page_path(@conn, :stats)} class={active_link_class(@conn, MailgunLoggerWeb.PageController, :stats)}>Stats</.link></li>
-                <li><.link href={Routes.account_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}>Accounts</.link></li>
-                <li><.link href={Routes.user_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}>Users</.link></li>
+                <li>
+                  <.link
+                    href={Routes.page_path(@conn, :stats)}
+                    class={active_link_class(@conn, MailgunLoggerWeb.PageController, :stats)}
+                  >
+                    Stats
+                  </.link>
+                </li>
+                <li>
+                  <.link
+                    href={Routes.account_path(@conn, :index)}
+                    class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}
+                  >
+                    Accounts
+                  </.link>
+                </li>
+                <li>
+                  <.link
+                    href={Routes.user_path(@conn, :index)}
+                    class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}
+                  >
+                    Users
+                  </.link>
+                </li>
               <% end %>
 
               <li class="nav-right">
                 <details class="nav-dropdown">
                   <summary class="nav-dropdown-toggle">
-                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path fill-rule="evenodd" d="M7.429 1.525a3.5 3.5 0 011.142 0 .75.75 0 01.57.549l.246 1.058a1.08 1.08 0 001.466.625l.97-.478a.75.75 0 01.758.069 5.5 5.5 0 01.572.572.75.75 0 01.069.758l-.478.97a1.08 1.08 0 00.625 1.466l1.058.246a.75.75 0 01.549.57 3.5 3.5 0 010 1.142.75.75 0 01-.549.57l-1.058.246a1.08 1.08 0 00-.625 1.466l.478.97a.75.75 0 01-.069.758 5.5 5.5 0 01-.572.572.75.75 0 01-.758.069l-.97-.478a1.08 1.08 0 00-1.466.625l-.246 1.058a.75.75 0 01-.57.549 3.5 3.5 0 01-1.142 0 .75.75 0 01-.57-.549l-.246-1.058a1.08 1.08 0 00-1.466-.625l-.97.478a.75.75 0 01-.758-.069 5.5 5.5 0 01-.572-.572.75.75 0 01-.069-.758l.478-.97a1.08 1.08 0 00-.625-1.466l-1.058-.246a.75.75 0 01-.549-.57 3.5 3.5 0 010-1.142.75.75 0 01.549-.57l1.058-.246a1.08 1.08 0 00.625-1.466l-.478-.97a.75.75 0 01.069-.758 5.5 5.5 0 01.572-.572.75.75 0 01.758-.069l.97.478a1.08 1.08 0 001.466-.625l.246-1.058a.75.75 0 01.57-.549zM8 11a3 3 0 100-6 3 3 0 000 6z"/></svg>
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                      <path
+                        fill-rule="evenodd"
+                        d="M7.429 1.525a3.5 3.5 0 011.142 0 .75.75 0 01.57.549l.246 1.058a1.08 1.08 0 001.466.625l.97-.478a.75.75 0 01.758.069 5.5 5.5 0 01.572.572.75.75 0 01.069.758l-.478.97a1.08 1.08 0 00.625 1.466l1.058.246a.75.75 0 01.549.57 3.5 3.5 0 010 1.142.75.75 0 01-.549.57l-1.058.246a1.08 1.08 0 00-.625 1.466l.478.97a.75.75 0 01-.069.758 5.5 5.5 0 01-.572.572.75.75 0 01-.758.069l-.97-.478a1.08 1.08 0 00-1.466.625l-.246 1.058a.75.75 0 01-.57.549 3.5 3.5 0 01-1.142 0 .75.75 0 01-.57-.549l-.246-1.058a1.08 1.08 0 00-1.466-.625l-.97.478a.75.75 0 01-.758-.069 5.5 5.5 0 01-.572-.572.75.75 0 01-.069-.758l.478-.97a1.08 1.08 0 00-.625-1.466l-1.058-.246a.75.75 0 01-.549-.57 3.5 3.5 0 010-1.142.75.75 0 01.549-.57l1.058-.246a1.08 1.08 0 00.625-1.466l-.478-.97a.75.75 0 01.069-.758 5.5 5.5 0 01.572-.572.75.75 0 01.758-.069l.97.478a1.08 1.08 0 001.466-.625l.246-1.058a.75.75 0 01.57-.549zM8 11a3 3 0 100-6 3 3 0 000 6z"
+                      />
+                    </svg>
                   </summary>
                   <div class="nav-dropdown-menu">
-                    <div class="nav-dropdown-header"><%= @current_user.email %></div>
+                    <div class="nav-dropdown-header">{@current_user.email}</div>
                     <div class="nav-dropdown-divider"></div>
-                    <.link href={Routes.profile_path(@conn, :edit)} class="nav-dropdown-item">Profile</.link>
-                    <.link href={Routes.auth_path(@conn, :logout)} class="nav-dropdown-item">Logout</.link>
+                    <.link href={Routes.profile_path(@conn, :edit)} class="nav-dropdown-item">
+                      Profile
+                    </.link>
+                    <.link href={Routes.auth_path(@conn, :logout)} class="nav-dropdown-item">
+                      Logout
+                    </.link>
                   </div>
                 </details>
               </li>
@@ -69,13 +110,18 @@
       </div>
     </header>
     <main>
-      <%= @inner_content %>
+      {@inner_content}
     </main>
     <footer>
-      <.link href={Routes.page_path(@conn, :non_affiliation)}>Mailgun</.link> Logger v<%= Application.spec(:mailgun_logger, :vsn) %>
-      | created by Jack + Joe | <a href="https://raw.githubusercontent.com/jackjoe/mailgun_logger/master/LICENSE">MIT License</a>
+      <.link href={Routes.page_path(@conn, :non_affiliation)}>Mailgun</.link>
+      Logger v{Application.spec(:mailgun_logger, :vsn)} | created by Jack + Joe |
+      <a href="https://raw.githubusercontent.com/jackjoe/mailgun_logger/master/LICENSE">
+        MIT License
+      </a>
     </footer>
-    <script defer phx-track-static src={Routes.static_path(@conn, "/assets/js/app.js")}></script>
-    <script src={Routes.static_path(@conn, "/assets/js/util.js")}></script>
+    <script defer phx-track-static src={Routes.static_path(@conn, "/assets/js/app.js")}>
+    </script>
+    <script src={Routes.static_path(@conn, "/assets/js/util.js")}>
+    </script>
   </body>
 </html>

--- a/lib/mailgun_logger_web/templates/layout/setup.html.heex
+++ b/lib/mailgun_logger_web/templates/layout/setup.html.heex
@@ -1,18 +1,23 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="Jack + Joe">
-    <meta name="version" content={Application.spec(:mailgun_logger, :vsn)}>
-    <meta name="env" content={to_string(Application.get_env(:mailgun_logger, :env))}>
-    <title>Mailgun Logger v<%= Application.spec(:mailgun_logger, :vsn) %></title>
-    <link rel="icon" type="image/png" href={Routes.static_path(@conn, "/assets/images/favicon.png")} />
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/css/style.css")}>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="author" content="Jack + Joe" />
+    <meta name="version" content={Application.spec(:mailgun_logger, :vsn)} />
+    <meta name="env" content={to_string(Application.get_env(:mailgun_logger, :env))} />
+    <title>Mailgun Logger v{Application.spec(:mailgun_logger, :vsn)}</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href={Routes.static_path(@conn, "/assets/images/favicon.png")}
+    />
+    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/css/style.css")} />
     <meta name="csrf-token" content={Plug.CSRFProtection.get_csrf_token()} />
   </head>
   <body>
-    <%= @inner_content %>
-    <script defer phx-track-static src={Routes.static_path(@conn, "/assets/js/app.js")}></script>
+    {@inner_content}
+    <script defer phx-track-static src={Routes.static_path(@conn, "/assets/js/app.js")}>
+    </script>
   </body>
 </html>

--- a/lib/mailgun_logger_web/templates/page/graphs.html.heex
+++ b/lib/mailgun_logger_web/templates/page/graphs.html.heex
@@ -2,7 +2,13 @@
   <h3>System</h3>
   <dl>
     <dt>Sent in the last 24h</dt>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js" integrity="sha512-ElRFoEQdI5Ht6kZvyzXhYG9NqjtkmlkfYk0wr6wHxU9JEHakS7UJZNeml5ALk+8IKlU6jDgMabC3vkumRokgJA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"
+      integrity="sha512-ElRFoEQdI5Ht6kZvyzXhYG9NqjtkmlkfYk0wr6wHxU9JEHakS7UJZNeml5ALk+8IKlU6jDgMabC3vkumRokgJA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    >
+    </script>
 
     <div class="container">
       <style>

--- a/lib/mailgun_logger_web/templates/page/stats.html.heex
+++ b/lib/mailgun_logger_web/templates/page/stats.html.heex
@@ -3,26 +3,26 @@
 <div>
   <div :if={@total_accounts == 0} class="warn">
     <strong>Note:</strong>
-    no accounts found...
-    <.link href={Routes.account_path(@conn, :new)}>create an account</.link> to start receiving logs.
+    no accounts found... <.link href={Routes.account_path(@conn, :new)}>create an account</.link>
+    to start receiving logs.
   </div>
   <div :if={Phoenix.Flash.get(@flash, :info)} class="info" role="info">
-    <%= Phoenix.Flash.get(@flash, :info) %>
+    {Phoenix.Flash.get(@flash, :info)}
   </div>
   <h2>Some stats</h2>
   <h3>Event counts by type (all time)</h3>
   <dl>
     <dt>Failed:</dt>
-    <dd><%= @event_counts.by_type["failed"] %></dd>
+    <dd>{@event_counts.by_type["failed"]}</dd>
     <dt>Accepted:</dt>
-    <dd><%= @event_counts.by_type["accepted"] %></dd>
+    <dd>{@event_counts.by_type["accepted"]}</dd>
     <dt>Delivered:</dt>
-    <dd><%= @event_counts.by_type["delivered"] %></dd>
+    <dd>{@event_counts.by_type["delivered"]}</dd>
     <dt>Clicked:</dt>
-    <dd><%= @event_counts.by_type["clicked"] %></dd>
+    <dd>{@event_counts.by_type["clicked"]}</dd>
     <dt>Opened:</dt>
-    <dd><%= @event_counts.by_type["opened"] %></dd>
+    <dd>{@event_counts.by_type["opened"]}</dd>
     <dt>Stored:</dt>
-    <dd><%= @event_counts.by_type["stored"] %></dd>
+    <dd>{@event_counts.by_type["stored"]}</dd>
   </dl>
 </div>

--- a/lib/mailgun_logger_web/templates/password_reset/request_done.html.heex
+++ b/lib/mailgun_logger_web/templates/password_reset/request_done.html.heex
@@ -1,4 +1,4 @@
 <div class="mx-auto panel">
-  <h2 class="h2"><%= gettext "Password forgot" %></h2>
-  <p><%= gettext "We sent you a link to reset your password." %></p>
+  <h2 class="h2">{gettext("Password forgot")}</h2>
+  <p>{gettext("We sent you a link to reset your password.")}</p>
 </div>

--- a/lib/mailgun_logger_web/templates/password_reset/request_new.html.heex
+++ b/lib/mailgun_logger_web/templates/password_reset/request_new.html.heex
@@ -1,13 +1,23 @@
 <div class="mx-auto panel">
   <.form for={@conn} action={Routes.password_reset_path(@conn, :request_create)}>
-    <h2 class="h2"><%= gettext "Password forgot" %></h2>
-    <p class="mb-4"><%= gettext "Enter the email address you registered with and we will send you an email with instructions on how to reset your password" %></p>
+    <h2 class="h2">{gettext("Password forgot")}</h2>
+    <p class="mb-4">
+      {gettext(
+        "Enter the email address you registered with and we will send you an email with instructions on how to reset your password"
+      )}
+    </p>
 
     <div class="form-group">
-      <label for="password_reset_email"><%= gettext("Email") %></label>
-      <input type="email" name="password_reset[email]" id="password_reset_email" required class="form-control" />
+      <label for="password_reset_email">{gettext("Email")}</label>
+      <input
+        type="email"
+        name="password_reset[email]"
+        id="password_reset_email"
+        required
+        class="form-control"
+      />
     </div>
 
-    <%= submit gettext("Send"), class: "btn btn-primary" %>
+    {submit(gettext("Send"), class: "btn btn-primary")}
   </.form>
 </div>

--- a/lib/mailgun_logger_web/templates/password_reset/reset_done.html.heex
+++ b/lib/mailgun_logger_web/templates/password_reset/reset_done.html.heex
@@ -1,5 +1,5 @@
 <div class="mx-auto panel">
-  <h2 class="h2"><%= gettext "Password forgot" %></h2>
-  <p class="mb-4"><%= gettext "Your password was reset." %></p>
-  <.link href={Routes.auth_path(@conn, :new)} class="btn btn-primary"><%= gettext("Login") %></.link>
+  <h2 class="h2">{gettext("Password forgot")}</h2>
+  <p class="mb-4">{gettext("Your password was reset.")}</p>
+  <.link href={Routes.auth_path(@conn, :new)} class="btn btn-primary">{gettext("Login")}</.link>
 </div>

--- a/lib/mailgun_logger_web/templates/password_reset/reset_error.html.heex
+++ b/lib/mailgun_logger_web/templates/password_reset/reset_error.html.heex
@@ -1,18 +1,20 @@
 <div class="mx-auto panel">
-  <h2 class="h2"><%= gettext "Password forgot" %></h2>
-  <h3 class="h3"><%= gettext "Invalid token" %></h3>
+  <h2 class="h2">{gettext("Password forgot")}</h2>
+  <h3 class="h3">{gettext("Invalid token")}</h3>
   <p class="mb-4">
-    <%= raw(gettext(
-      """
-      This password reset link is invalid.
-      You can try to %{request_open} request a new password %{link_close} or
-      continue to the %{login_open}login screen%{link_close}.
-      """,
-      %{
-        request_open: "<a href=\"#{Routes.password_reset_path(@conn, :request_new)}\">",
-        login_open: "<a href=\"#{Routes.auth_path(@conn, :new)}\">",
-        link_close: "</a>"
-      }
-    )) %>
+    {raw(
+      gettext(
+        """
+        This password reset link is invalid.
+        You can try to %{request_open} request a new password %{link_close} or
+        continue to the %{login_open}login screen%{link_close}.
+        """,
+        %{
+          request_open: "<a href=\"#{Routes.password_reset_path(@conn, :request_new)}\">",
+          login_open: "<a href=\"#{Routes.auth_path(@conn, :new)}\">",
+          link_close: "</a>"
+        }
+      )
+    )}
   </p>
 </div>

--- a/lib/mailgun_logger_web/templates/password_reset/reset_new.html.heex
+++ b/lib/mailgun_logger_web/templates/password_reset/reset_new.html.heex
@@ -1,11 +1,20 @@
 <div class="mx-auto panel">
-  <.form :let={f} for={@changeset} action={Routes.password_reset_path(@conn, :reset_create, @reset_token)}>
-    <h2 class="h2"><%= gettext "Password forgot" %></h2>
-    <p class="mb-4"><%= gettext "Enter and confirm your new password" %></p>
+  <.form
+    :let={f}
+    for={@changeset}
+    action={Routes.password_reset_path(@conn, :reset_create, @reset_token)}
+  >
+    <h2 class="h2">{gettext("Password forgot")}</h2>
+    <p class="mb-4">{gettext("Enter and confirm your new password")}</p>
 
     <.input field={f[:password]} type="password" label={gettext("Wachtwoord")} required />
-    <.input field={f[:password_confirmation]} type="password" label={gettext("Wachtwoord bevestigen")} required />
+    <.input
+      field={f[:password_confirmation]}
+      type="password"
+      label={gettext("Wachtwoord bevestigen")}
+      required
+    />
 
-    <%= submit gettext("Reset password"), class: "btn btn-primary" %>
+    {submit(gettext("Reset password"), class: "btn btn-primary")}
   </.form>
 </div>

--- a/lib/mailgun_logger_web/templates/setup/index.html.heex
+++ b/lib/mailgun_logger_web/templates/setup/index.html.heex
@@ -1,6 +1,6 @@
 <main>
   <.form :let={f} for={@changeset} action={Routes.setup_path(@conn, :create_root)}>
-    <h1><%= gettext("Welcome newbie!") %></h1>
+    <h1>{gettext("Welcome newbie!")}</h1>
     <p>Looks like this is the first time you are accessing Mailgun Logger.</p>
     <p>Create the admin account below:</p>
 
@@ -8,7 +8,7 @@
     <.input field={f[:password]} type="password" label="Password" />
 
     <div class="form-group mt-5">
-      <%= submit "submit" %>
+      {submit("submit")}
     </div>
   </.form>
 </main>

--- a/lib/mailgun_logger_web/templates/user/edit.html.heex
+++ b/lib/mailgun_logger_web/templates/user/edit.html.heex
@@ -1,4 +1,16 @@
 <h1>Edit user</h1>
-<%= render "form.html", action: Routes.user_path(@conn, :update, @user), changeset: @changeset, new?: false, flash: @flash %>
+{render("form.html",
+  action: Routes.user_path(@conn, :update, @user),
+  changeset: @changeset,
+  new?: false,
+  flash: @flash
+)}
 <br />
-<.link href={Routes.user_path(@conn, :delete, @user)} method="delete" data-confirm="Are you sure?" class="btn btn-danger btn-sm">delete</.link>
+<.link
+  href={Routes.user_path(@conn, :delete, @user)}
+  method="delete"
+  data-confirm="Are you sure?"
+  class="btn btn-danger btn-sm"
+>
+  delete
+</.link>

--- a/lib/mailgun_logger_web/templates/user/edit.html.heex
+++ b/lib/mailgun_logger_web/templates/user/edit.html.heex
@@ -3,7 +3,10 @@
   action: Routes.user_path(@conn, :update, @user),
   changeset: @changeset,
   new?: false,
-  flash: @flash
+  flash: @flash,
+  all_roles: @all_roles,
+  selected_role_ids: @selected_role_ids,
+  show_roles?: @show_roles?
 )}
 <br />
 <.link

--- a/lib/mailgun_logger_web/templates/user/form.html.heex
+++ b/lib/mailgun_logger_web/templates/user/form.html.heex
@@ -7,6 +7,10 @@
     {Phoenix.Flash.get(@flash, :info)}
   </div>
 
+  <div :if={Phoenix.Flash.get(@flash, :error)} class="alert alert-danger" role="alert">
+    {Phoenix.Flash.get(@flash, :error)}
+  </div>
+
   <.input field={f[:firstname]} label="Firstname" />
   <.input field={f[:lastname]} label="Lastname" />
   <.input field={f[:email]} label="Email" />
@@ -17,6 +21,22 @@
     label="Theme"
     options={[{"System", "system"}, {"Light", "light"}, {"Dark", "dark"}]}
   />
+
+  <div :if={@show_roles?} class="form-group">
+    <label>Roles</label>
+    <div class="role-checkboxes">
+      <div :for={role <- @all_roles} class="role-option">
+        <input
+          type="checkbox"
+          name="user[role_ids][]"
+          value={role.id}
+          checked={role.id in @selected_role_ids}
+          id={"role_#{role.id}"}
+        />
+        <label for={"role_#{role.id}"}>{role.name}</label>
+      </div>
+    </div>
+  </div>
 
   <div class="form-group mt-5">
     {submit("submit", class: "btn btn-primary")}

--- a/lib/mailgun_logger_web/templates/user/index.html.heex
+++ b/lib/mailgun_logger_web/templates/user/index.html.heex
@@ -11,12 +11,12 @@
   </thead>
   <tbody>
     <%= for user <- @users do %>
-    <tr>
-      <td><%= "#{user.firstname || ""} #{user.lastname || ""}" |> String.trim() %></td>
-      <td><%= user.email %></td>
-      <td><%= Enum.map(user.roles, & &1.name) %></td>
-      <td><.link href={Routes.user_path(@conn, :edit, user)}>edit</.link></td>
-    </tr>
+      <tr>
+        <td>{"#{user.firstname || ""} #{user.lastname || ""}" |> String.trim()}</td>
+        <td>{user.email}</td>
+        <td>{Enum.map(user.roles, & &1.name)}</td>
+        <td><.link href={Routes.user_path(@conn, :edit, user)}>edit</.link></td>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/lib/mailgun_logger_web/templates/user/index.html.heex
+++ b/lib/mailgun_logger_web/templates/user/index.html.heex
@@ -1,5 +1,9 @@
 <h1>Users</h1>
 
+<div :if={Phoenix.Flash.get(@flash, :info)} class="alert alert-info">
+  {Phoenix.Flash.get(@flash, :info)}
+</div>
+
 <table cellspacing="0" class="table">
   <thead>
     <tr>

--- a/lib/mailgun_logger_web/templates/user/new.html.heex
+++ b/lib/mailgun_logger_web/templates/user/new.html.heex
@@ -3,5 +3,8 @@
   action: Routes.user_path(@conn, :create),
   changeset: @changeset,
   flash: @flash,
-  new?: true
+  new?: true,
+  all_roles: @all_roles,
+  selected_role_ids: @selected_role_ids,
+  show_roles?: @show_roles?
 )}

--- a/lib/mailgun_logger_web/templates/user/new.html.heex
+++ b/lib/mailgun_logger_web/templates/user/new.html.heex
@@ -1,2 +1,7 @@
 <h1>New user</h1>
-<%= render "form.html", action: Routes.user_path(@conn, :create), changeset: @changeset, flash: @flash, new?: true %>
+{render("form.html",
+  action: Routes.user_path(@conn, :create),
+  changeset: @changeset,
+  flash: @flash,
+  new?: true
+)}

--- a/lib/mailgun_logger_web/templates/user/profile.html.heex
+++ b/lib/mailgun_logger_web/templates/user/profile.html.heex
@@ -1,2 +1,7 @@
 <h1>Profile</h1>
-<%= render "form.html", action: Routes.profile_path(@conn, :update), changeset: @changeset, new?: false, flash: @flash %>
+{render("form.html",
+  action: Routes.profile_path(@conn, :update),
+  changeset: @changeset,
+  new?: false,
+  flash: @flash
+)}

--- a/lib/mailgun_logger_web/views/event_view.ex
+++ b/lib/mailgun_logger_web/views/event_view.ex
@@ -16,7 +16,7 @@ defmodule MailgunLoggerWeb.EventView do
     assigns = %{name: name}
 
     ~H"""
-    <span class={"log-event log-event--#{@name}"}><%= @name %></span>
+    <span class={"log-event log-event--#{@name}"}>{@name}</span>
     """
   end
 
@@ -34,7 +34,7 @@ defmodule MailgunLoggerWeb.EventView do
     assigns = %{event_type: event_type}
 
     ~H"""
-    <span class="log-level log-level--error"><%= @event_type %></span>
+    <span class="log-level log-level--error">{@event_type}</span>
     """
   end
 
@@ -70,7 +70,7 @@ defmodule MailgunLoggerWeb.EventView do
 
     ~H"""
     <code style="white-space: break-spaces">
-      <%= @html %>
+      {@html}
     </code>
     """
   end
@@ -86,7 +86,7 @@ defmodule MailgunLoggerWeb.EventView do
     </div>
     <ul style="padding:0;">
       <%= for a <- @attachments do %>
-        <li><%= a %></li>
+        <li>{a}</li>
       <% end %>
     </ul>
     """

--- a/priv/static/assets/css/style.css
+++ b/priv/static/assets/css/style.css
@@ -330,6 +330,31 @@ input[type="checkbox"] {
   cursor: pointer;
 }
 
+.role-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.role-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--c-border);
+  cursor: pointer;
+}
+
+.role-option:hover {
+  border-color: var(--c-accent);
+}
+
+.role-option label {
+  margin-bottom: 0;
+  cursor: pointer;
+}
+
 /* ---- Buttons ---- */
 
 button,

--- a/test/lib/mailgun_logger/roles/roles_test.exs
+++ b/test/lib/mailgun_logger/roles/roles_test.exs
@@ -1,0 +1,27 @@
+defmodule MailgunLogger.RolesTest do
+  use MailgunLogger.DataCase
+
+  alias MailgunLogger.Roles
+
+  describe "can?/2 for :manage_roles" do
+    test "admin can manage_roles" do
+      user = insert(:user, roles: [build(:role, name: "admin")])
+      assert Roles.can?(user, :manage_roles)
+    end
+
+    test "superuser can manage_roles" do
+      user = insert(:user, roles: [build(:role, name: "superuser")])
+      assert Roles.can?(user, :manage_roles)
+    end
+
+    test "member cannot manage_roles" do
+      user = insert(:user, roles: [build(:role, name: "member")])
+      refute Roles.can?(user, :manage_roles)
+    end
+
+    test "user with no roles cannot manage_roles" do
+      user = insert(:user, roles: [])
+      refute Roles.can?(user, :manage_roles)
+    end
+  end
+end

--- a/test/lib/mailgun_logger/users/users_test.exs
+++ b/test/lib/mailgun_logger/users/users_test.exs
@@ -1,0 +1,74 @@
+defmodule MailgunLogger.UsersTest do
+  use MailgunLogger.DataCase
+
+  alias MailgunLogger.Users
+
+  describe "create_user_with_roles/2" do
+    test "creates user with assigned roles atomically" do
+      admin_role = insert(:role, name: "admin")
+
+      {:ok, user} =
+        Users.create_user_with_roles(
+          %{email: "new@example.com", password: "password123"},
+          [admin_role]
+        )
+
+      assert Enum.map(user.roles, & &1.name) == ["admin"]
+    end
+
+    test "creates user with no roles when given empty list" do
+      {:ok, user} =
+        Users.create_user_with_roles(
+          %{email: "norole@example.com", password: "password123"},
+          []
+        )
+
+      assert user.roles == []
+    end
+  end
+
+  describe "update_user_with_ro les/3" do
+    test "replaces existing roles atomically" do
+      member_role = insert(:role, name: "member")
+      admin_role = insert(:role, name: "admin")
+      user = insert(:user, roles: [member_role])
+
+      {:ok, updated} = Users.update_user_with_roles(user, %{}, [admin_role])
+
+      assert Enum.map(updated.roles, & &1.name) == ["admin"]
+    end
+
+    test "removes all roles when given empty list" do
+      admin_role = insert(:role, name: "admin")
+      user = insert(:user, roles: [admin_role])
+
+      {:ok, updated} = Users.update_user_with_roles(user, %{}, [])
+
+      assert updated.roles == []
+    end
+
+    test "assigns multiple roles at once" do
+      member_role = insert(:role, name: "member")
+      admin_role = insert(:role, name: "admin")
+      user = insert(:user, roles: [])
+
+      {:ok, updated} = Users.update_user_with_roles(user, %{}, [member_role, admin_role])
+
+      role_names = Enum.map(updated.roles, & &1.name) |> Enum.sort()
+      assert role_names == ["admin", "member"]
+    end
+
+    test "returns error and makes no changes when profile update fails" do
+      admin_role = insert(:role, name: "admin")
+      user = insert(:user, roles: [admin_role])
+      other_user = insert(:user, roles: [])
+
+      assert {:error, _changeset} =
+               Users.update_user_with_roles(user, %{email: other_user.email}, [])
+
+      # roles unchanged
+      reloaded = Users.get_user!(user.id)
+      assert Enum.map(reloaded.roles, & &1.name) == ["admin"]
+    end
+  end
+end

--- a/test/lib/mailgun_logger/users/users_test.exs
+++ b/test/lib/mailgun_logger/users/users_test.exs
@@ -27,7 +27,7 @@ defmodule MailgunLogger.UsersTest do
     end
   end
 
-  describe "update_user_with_ro les/3" do
+  describe "update_user_with_roles/3" do
     test "replaces existing roles atomically" do
       member_role = insert(:role, name: "member")
       admin_role = insert(:role, name: "admin")


### PR DESCRIPTION
 ## Role-based access control + role assignment UI

  **Task 1 — Member role**

  - Added member role scoped to Events page and its detail pages
  - Stats, Accounts, and Users blocked in both nav and at route level via pipeline guards
  - Members can still edit their own profile via /profile

  **Task 2 — Role assignment on Create/Edit user**

  - Role checkboxes on Create/Edit forms, visible only to admin/superuser (manage_roles permission)
  - Atomic role assignment using put_assoc — no partial state on failure
  - Server-side guard: role_ids from non-admin POSTs are silently ignored
  - Self-downgrade blocked: a user cannot remove their own roles

  **Tests**

  - Roles.can?/2 for manage_roles across all role types
  - create_user_with_roles/2 and update_user_with_roles/3 covering assignment, replacement, empty list, and atomicity on failure
 
## Definition of Done

**Task 1 – Member role**
- [x] Seeding data updated with member role
- [x] Role-based access implemented and working
- [x] Build compiles without warnings
- [x] Application runs

**Task 2 – Role assignment**
- [x] Admins and superusers can assign roles via Create/Edit user forms
- [x] Self-downgrade considered and handled
- [x] Unit tests written and passing