### PR TITLE
toevoegen member rol en instellen permissies voor rollen

### DIFF
--- a/lib/mailgun_logger/roles/roles.ex
+++ b/lib/mailgun_logger/roles/roles.ex
@@ -5,6 +5,7 @@ defmodule MailgunLogger.Roles do
   alias MailgunLogger.User
   alias MailgunLogger.Repo
 
+  @member_role "member"
   @superuser_role "superuser"
   @admin_role "admin"
 
@@ -12,7 +13,10 @@ defmodule MailgunLogger.Roles do
 
   @default_actions ~w()
 
-  @admin_actions ~w(do_stuff) ++ @default_actions
+  @member_actions ~w(view_events) ++ @default_actions
+
+  # @admin_actions ~w(do_stuff) ++ @default_actions
+  @admin_actions ~w(admin_actions manage_users) ++ @member_actions
 
   @superuser_actions ~w() ++ @admin_actions
 
@@ -55,6 +59,11 @@ defmodule MailgunLogger.Roles do
     Enum.any?(roles, &can?(&1.name, action))
   end
 
+  for action <- @member_actions do
+    action = String.to_atom(action)
+    def can?(@member_role, unquote(action)), do: true
+  end
+
   for action <- @admin_actions do
     action = String.to_atom(action)
     def can?(@admin_role, unquote(action)), do: true
@@ -69,12 +78,14 @@ defmodule MailgunLogger.Roles do
 
   def is?(%User{roles: roles}, :superuser), do: is(roles, "superuser")
   def is?(%User{roles: roles}, :admin), do: is(roles, "admin")
+  def is?(%User{roles: roles}, :member), do: is(roles, "member")
   def is?(_, _), do: raise("Roles.is/2 requires roles to be preloaded")
 
   defp is(roles, role) when is_binary(role), do: Enum.map(roles, & &1.name) |> Enum.member?(role)
 
   def abilities(%User{roles: []}), do: []
   def abilities(%User{roles: roles}), do: hd(roles) |> abilities()
+  def abilities(%Role{name: "member"}), do: @member_actions
   def abilities(%Role{name: "admin"}), do: @admin_actions
   def abilities(%Role{name: "superuser"}), do: @superuser_actions
 

--- a/lib/mailgun_logger/seeder.ex
+++ b/lib/mailgun_logger/seeder.ex
@@ -6,7 +6,8 @@ defmodule MailgunLogger.Seeder do
 
   # alias MailgunLogger.UserRole
 
-  @roles [%Role{name: "superuser"}, %Role{name: "admin"}]
+  # @roles [%Role{name: "superuser"}, %Role{name: "admin"}]
+  @roles [%Role{name: "superuser"}, %Role{name: "admin"}, %Role{name: "member"}]
 
   def run do
     Enum.each(@roles, &insert_if_new(&1))

--- a/lib/mailgun_logger/users/users.ex
+++ b/lib/mailgun_logger/users/users.ex
@@ -162,4 +162,22 @@ defmodule MailgunLogger.Users do
   def delete_user(%User{} = user) do
     Repo.delete(user)
   end
+
+  @spec create_user_with_role(map(), String.t()) :: ecto_user()
+  def create_user_with_role(params, role_name) do
+    role = MailgunLogger.Roles.get_role_by_name(role_name)
+    %User{}
+    |> User.changeset(params)
+    |> Ecto.Changeset.put_assoc(:roles, [role])
+    |> Repo.insert()
+  end
+
+  @spec update_user_role(User.t(), String.t()) :: ecto_user()
+  def update_user_role(%User{} = user, role_name) do
+    role = MailgunLogger.Roles.get_role_by_name(role_name)
+    user
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_assoc(:roles, [role])
+    |> Repo.update()
+  end
 end

--- a/lib/mailgun_logger_web/controllers/page_controller.ex
+++ b/lib/mailgun_logger_web/controllers/page_controller.ex
@@ -5,7 +5,13 @@ defmodule MailgunLoggerWeb.PageController do
   alias MailgunLogger.Accounts
 
   def index(conn, _) do
-    redirect(conn, to: Routes.event_path(conn, :index))
+    # redirect(conn, to: Routes.event_path(conn, :index))
+    user = conn.assigns[:current_user]
+    if MailgunLogger.Roles.can?(user, :view_events) do
+      redirect(conn, to: Routes.event_path(conn, :index))
+    else
+      redirect(conn, to: Routes.profile_path(conn, :edit))
+    end
   end
 
   def trigger_run(conn, _) do

--- a/lib/mailgun_logger_web/controllers/user_controller.ex
+++ b/lib/mailgun_logger_web/controllers/user_controller.ex
@@ -9,33 +9,74 @@ defmodule MailgunLoggerWeb.UserController do
     render(conn, :index, users: users)
   end
 
+  # def new(conn, _) do
+  #   changeset = User.changeset(%User{})
+  #   render(conn, :new, changeset: changeset)
+  # end
+
   def new(conn, _) do
     changeset = User.changeset(%User{})
-    render(conn, :new, changeset: changeset)
+    render(conn, :new, changeset: changeset, new?: true, current_user: conn.assigns[:current_user])
   end
 
+  # def create(conn, %{"user" => params}) do
+  #   case Users.create_user(params) do
+  #     {:ok, _} -> redirect(conn, to: Routes.user_path(conn, :index))
+  #     {:error, changeset} -> render(conn, :new, changeset: changeset)
+  #   end
+  # end
+
   def create(conn, %{"user" => params}) do
-    case Users.create_user(params) do
+    role = Map.get(params, "role", "member")
+    case Users.create_user_with_role(params, role) do
       {:ok, _} -> redirect(conn, to: Routes.user_path(conn, :index))
-      {:error, changeset} -> render(conn, :new, changeset: changeset)
+      {:error, changeset} -> render(conn, :new, changeset: changeset, new?: true, current_user: conn.assigns[:current_user])
     end
   end
 
+  # def edit(conn, %{"id" => id}) do
+  #   user = Users.get_user!(id)
+  #   changeset = User.changeset(user)
+  #   render(conn, :edit, changeset: changeset, user: user)
+  # end
+
   def edit(conn, %{"id" => id}) do
     user = Users.get_user!(id)
-    changeset = User.changeset(user)
-    render(conn, :edit, changeset: changeset, user: user)
+    changeset = User.update_changeset(user)
+    render(conn, :edit, changeset: changeset, user: user, new?: false, current_user: conn.assigns[:current_user])
   end
+
+  # def update(conn, %{"id" => id, "user" => params}) do
+  #   user = Users.get_user!(id)
+
+  #   case Users.update_user(user, params) do
+  #     {:ok, _} ->
+  #       redirect(conn, to: Routes.user_path(conn, :index))
+
+  #     {:error, changeset} ->
+  #       render(conn, :edit, changeset: changeset, user: user)
+  #   end
+  # end
 
   def update(conn, %{"id" => id, "user" => params}) do
     user = Users.get_user!(id)
+    role = Map.get(params, "role")
 
-    case Users.update_user(user, params) do
-      {:ok, _} ->
+    # to check current user's role
+    current_user = conn.assigns[:current_user]
+
+    # Block self-downgrade and upgrade
+    if to_string(user.id) == to_string(current_user.id) && role != hd(current_user.roles).name do
+      conn
+      |> put_flash(:error, "You can't change your own role.")
+      |> redirect(to: Routes.user_path(conn, :edit, user))
+    else
+      with {:ok, user} <- Users.update_user(user, params),
+          {:ok, _} <- (if role, do: Users.update_user_role(user, role), else: {:ok, user}) do
         redirect(conn, to: Routes.user_path(conn, :index))
-
-      {:error, changeset} ->
-        render(conn, :edit, changeset: changeset, user: user)
+      else
+        {:error, changeset} -> render(conn, :edit, changeset: changeset, user: user, current_user: conn.assigns[:current_user])
+      end
     end
   end
 

--- a/lib/mailgun_logger_web/plugs/role_check.ex
+++ b/lib/mailgun_logger_web/plugs/role_check.ex
@@ -1,0 +1,20 @@
+defmodule MailgunLoggerWeb.Plugs.RoleCheck do
+  import Plug.Conn
+  import Phoenix.Controller
+  alias MailgunLogger.Roles
+  alias MailgunLoggerWeb.Router.Helpers, as: Routes
+
+  def init(action), do: action
+
+  def call(conn, action) do
+    user = conn.assigns[:current_user]
+    if Roles.can?(user, action) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "No access")
+      |> redirect(to: Routes.page_path(conn, :index))
+      |> halt()
+    end
+  end
+end

--- a/lib/mailgun_logger_web/router.ex
+++ b/lib/mailgun_logger_web/router.ex
@@ -23,6 +23,14 @@ defmodule MailgunLoggerWeb.Router do
     plug(MailgunLoggerWeb.Plugs.Auth)
   end
 
+  pipeline :can_view_events do
+    plug(MailgunLoggerWeb.Plugs.RoleCheck, :view_events)
+  end
+
+  pipeline :can_admin_actions do
+    plug(MailgunLoggerWeb.Plugs.RoleCheck, :admin_actions)
+  end
+
   # Always except in prod
   if Application.compile_env(:mailgun_logger, :env) == :dev do
     forward("/sent_emails", Bamboo.SentEmailViewerPlug)
@@ -69,22 +77,53 @@ defmodule MailgunLoggerWeb.Router do
     post("/", SetupController, :create_root)
   end
 
+  # scope "/", MailgunLoggerWeb do
+  #   pipe_through([:browser, :auth])
+
+  #   get("/logout", AuthController, :logout)
+
+  #   resources("/events", EventController, only: [:index, :show])
+  #   get("/events/:id/stored_message", EventController, :stored_message)
+  #   resources("/accounts", AccountController, except: [:show])
+  #   get("/profile", ProfileController, :edit)
+  #   put("/profile", ProfileController, :update)
+  #   resources("/users", UserController, except: [:show])
+
+  #   get("/", PageController, :index)
+  #   post("/trigger-run", PageController, :trigger_run)
+  #   get("/stats", PageController, :stats)
+  #   get("/graphs", PageController, :graphs)
+  #   get("/non-affiliation", PageController, :non_affiliation)
+  # end
+
   scope "/", MailgunLoggerWeb do
     pipe_through([:browser, :auth])
 
     get("/logout", AuthController, :logout)
+    get("/non-affiliation", PageController, :non_affiliation)
+
+    get("/profile", ProfileController, :edit)
+    put("/profile", ProfileController, :update)
+
+    get("/", PageController, :index)
+  end
+
+  scope "/", MailgunLoggerWeb do
+    pipe_through([:browser, :auth, :can_view_events])
 
     resources("/events", EventController, only: [:index, :show])
     get("/events/:id/stored_message", EventController, :stored_message)
-    resources("/accounts", AccountController, except: [:show])
-    get("/profile", ProfileController, :edit)
-    put("/profile", ProfileController, :update)
-    resources("/users", UserController, except: [:show])
 
-    get("/", PageController, :index)
+  end
+
+  scope "/", MailgunLoggerWeb do
+    pipe_through([:browser, :auth, :can_admin_actions])
+
     post("/trigger-run", PageController, :trigger_run)
     get("/stats", PageController, :stats)
     get("/graphs", PageController, :graphs)
-    get("/non-affiliation", PageController, :non_affiliation)
+    resources("/accounts", AccountController, except: [:show])
+    resources("/users", UserController, except: [:show])
   end
+
 end

--- a/lib/mailgun_logger_web/templates/layout/app.html.heex
+++ b/lib/mailgun_logger_web/templates/layout/app.html.heex
@@ -38,10 +38,14 @@
           </div>
           <ul>
             <%= if assigns[:current_user] do %>
-              <li><.link href={Routes.event_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.EventController)}>Events</.link></li>
-              <li><.link href={Routes.page_path(@conn, :stats)} class={active_link_class(@conn, MailgunLoggerWeb.PageController, :index)}>Stats</.link></li>
-              <li><.link href={Routes.account_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}>Accounts</.link></li>
-              <li><.link href={Routes.user_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}>Users</.link></li>
+              <%= if Roles.can?(@current_user, :view_events) do %>
+                <li><.link href={Routes.event_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.EventController)}>Events</.link></li>
+              <% end %>
+              <%= if Roles.can?(@current_user, :admin_actions) do %>
+                <li><.link href={Routes.page_path(@conn, :stats)} class={active_link_class(@conn, MailgunLoggerWeb.PageController, :index)}>Stats</.link></li>
+                <li><.link href={Routes.account_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.AccountController, :index)}>Accounts</.link></li>
+                <li><.link href={Routes.user_path(@conn, :index)} class={active_link_class(@conn, MailgunLoggerWeb.UserController, :index)}>Users</.link></li>
+              <% end %>
               <li class="nav-right">
                 <details class="nav-dropdown">
                   <summary class="nav-dropdown-toggle">

--- a/lib/mailgun_logger_web/templates/user/edit.html.heex
+++ b/lib/mailgun_logger_web/templates/user/edit.html.heex
@@ -1,4 +1,4 @@
 <h1>Edit user</h1>
-<%= render "form.html", action: Routes.user_path(@conn, :update, @user), changeset: @changeset, new?: false, flash: @flash %>
+<%= render "form.html", action: Routes.user_path(@conn, :update, @user), changeset: @changeset, new?: false, flash: @flash, current_user: @current_user, user: @user %>
 <br />
 <.link href={Routes.user_path(@conn, :delete, @user)} method="delete" data-confirm="Are you sure?" class="btn btn-danger btn-sm">delete</.link>

--- a/lib/mailgun_logger_web/templates/user/form.html.heex
+++ b/lib/mailgun_logger_web/templates/user/form.html.heex
@@ -11,6 +11,28 @@
   <.input field={f[:lastname]} label="Lastname" />
   <.input field={f[:email]} label="Email" />
   <.input :if={@new?} field={f[:password]} type="password" label="Password" />
+
+  <%= if Roles.can?(@current_user, :manage_users) && !String.contains?(@action, "profile") && (assigns[:user] == nil || @current_user.id != assigns[:user].id) do %>
+    
+    <%= if @new? do %>
+      <.input
+        field={f[:role]}
+        type="select"
+        label="Role"
+        options={[{"Member", "member"}, {"Admin", "admin"}, {"Superuser", "superuser"}]}
+      />
+    <% else %>
+      <.input
+        field={f[:role]}
+        type="select"
+        label="Role"
+        options={[{"Member", "member"}, {"Admin", "admin"}, {"Superuser", "superuser"}]}
+        value={if @changeset.data.roles != [], do: hd(@changeset.data.roles).name, else: "member"}
+      />
+    <% end %>
+
+  <% end %>
+
   <.input
     field={f[:theme]}
     type="select"

--- a/lib/mailgun_logger_web/templates/user/new.html.heex
+++ b/lib/mailgun_logger_web/templates/user/new.html.heex
@@ -1,2 +1,2 @@
 <h1>New user</h1>
-<%= render "form.html", action: Routes.user_path(@conn, :create), changeset: @changeset, flash: @flash, new?: true %>
+<%= render "form.html", action: Routes.user_path(@conn, :create), changeset: @changeset, flash: @flash, new?: true, current_user: @current_user %>

--- a/lib/mailgun_logger_web/templates/user/profile.html.heex
+++ b/lib/mailgun_logger_web/templates/user/profile.html.heex
@@ -1,2 +1,2 @@
 <h1>Profile</h1>
-<%= render "form.html", action: Routes.profile_path(@conn, :update), changeset: @changeset, new?: false, flash: @flash %>
+<%= render "form.html", action: Routes.profile_path(@conn, :update), changeset: @changeset, new?: false, flash: @flash, current_user: @current_user %>

--- a/lib/mailgun_logger_web/views/layout_view.ex
+++ b/lib/mailgun_logger_web/views/layout_view.ex
@@ -1,4 +1,5 @@
 defmodule MailgunLoggerWeb.LayoutView do
   use MailgunLoggerWeb, :view
+  alias MailgunLogger.Roles
   @moduledoc false
 end

--- a/lib/mailgun_logger_web/views/user_view.ex
+++ b/lib/mailgun_logger_web/views/user_view.ex
@@ -1,4 +1,5 @@
 defmodule MailgunLoggerWeb.UserView do
   use MailgunLoggerWeb, :view
+  alias MailgunLogger.Roles
   @moduledoc false
 end


### PR DESCRIPTION
overzicht aanpassingen Bart

mailgun_logger
- seeder.ex: initieel ook rol "member" voorzien
- roles.ex: extra "member" rol, toewijzen permissies per rol
- users.ex: aanmaken/updaten rol in database voor user

mailgun_logger_web
- plugs/role_check.ex: rol permissies checken en toelaten of blokkeren
- router.ex: opsplitsen pipe in meerdere, toelaten specifieke routes per rol/permissies
- page_controller.ex: redirect o.b.v. permissies
- user_controller.ex: bij new/create/edit rol-gerelateerde informatie doorgeven, bij update ook self-downgrade voorkomen
- layout/app.html.heex: tonen/verbergen navigatie links obv rol permissies
- templates/user/edit/new/profile.html.heex: doorgeven user/current_user
- templates/user/form.html.heex: rol select tonen voor juiste permissies, niet bij eigen /profile of via edit van eigen user
- views/layout/user_view.ex: Roles rechtstreeks aanroepbaar maken door toevoegen alias MailgunLogger.Roles
